### PR TITLE
updated get_move_delay to prevent passing a negative time

### DIFF
--- a/main.py
+++ b/main.py
@@ -325,21 +325,23 @@ def actions(engine: stockfish.Stockfish, driver: webdriver.Chrome, session):
         r_ = elo_rating_ if elo_rating_ > 0 else 2500
         is_capturing = engine.get_what_is_on_square(move[2:4])
         piece = engine.get_what_is_on_square(move[:2])
-        is_pawn = piece == Piece.BLACK_PAWN or piece == Piece.WHITE_PAWN
+        is_pawn = piece == stockfish.Stockfish.Piece.BLACK_PAWN or piece == stockfish.Stockfish.Piece.WHITE_PAWN
         if is_capturing or is_pawn:
             last_wt = max(0.0, last_wt - last_wt / random.randint(1, 3) - 2)
             return abs(random.random() / 3) * r_ / 2500
+
         wt_ = random.randint(0, 200) * random.randint(0, 1)
         if last_wt != 0:
             last_wt = max(0.0, last_wt - last_wt / random.randint(1, 3) - 2)
-            return (abs(random.random() / 4) + op_move_time * abs(random.random() / 2)) * game_timer / 60000 * r_ / 2500
+            return max(0.0, (abs(random.random() / 4) + op_move_time * abs(random.random() / 2)) * game_timer / 60000 * r_ / 2500)
+
         wt_ = wt_ if wt_ != 0 else random.randint(1000, 3000)
         wt_ = min(wt_ * stockfish_time * 6, timer_ // 8) / 1000
         wt_ = min(random.randint(2, 7), wt_)
         if last_wt == 0:
             last_wt = wt_
-        return (wt_ + op_move_time * abs(random.random() / 2) + abs(
-            random.random() / 2)) * game_timer / 60000 * r_ / 2500
+        #preventing passing a negative time (last_wt)
+        return max(0.0, (wt_ + op_move_time * abs(random.random() / 2) + abs(random.random() / 2)) * game_timer / 60000 * r_ / 2500)
 
     loop_id = 0
 


### PR DESCRIPTION
Avoiding situations like:

2024-01-04 13:24:58 [DEBUG] [chess-log, main.py:357]: wt=-0.007 **last_wt=-0.623**
Traceback (most recent call last):
  File "/Users/an/dev/playground/python/chess-com-bot/main.py", line 386, in loop
    return actions(engine, driver, session)
  File "/Users/an/dev/playground/python/chess-com-bot/main.py", line 358, in actions
    sleep(wt)
ValueError: sleep length must be non-negative
